### PR TITLE
[Feature] Add robust shadows and possibility to return measurements/shadows themselves

### DIFF
--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -87,7 +87,7 @@ shadow_measurement = Measurements(protocol=Measurements.SHADOW, options=shadow_o
 # Run the shadow experiment.
 estimated_values_shadow = shadow_measurement(model)
 
-print(f"Estimated expectation value tomo = {estimated_values_shadow}") # markdown-exec: hide
+print(f"Estimated expectation value shadow = {estimated_values_shadow}") # markdown-exec: hide
 ```
 
 ## Robust shadows
@@ -95,11 +95,11 @@ print(f"Estimated expectation value tomo = {estimated_values_shadow}") # markdow
 Robust shadows [^4] were built upon the classical shadow scheme but have the particularity to be noise-resilient. Using an experimentally friendly calibration procedure, one can eﬃciently characterize and mitigate noises in the shadow estimation scheme, given only minimal assumptions on the experimental conditions. Such a procedure has been used in [^5] to estimate the Quantum Fisher information out of a quantum system. Note that robust shadows are equivalent to classical shadows in non-noisy settings by setting `robust_correlations` to $\frac{1}{3}$ for each qubit as follows:
 
 ```python exec="on" source="material-block" session="measurements" result="json"
-shadow_options = {"accuracy": 0.1, "confidence": 0.1, "robust": True, "robust_correlations": [1.0 / 3.0] * 2}
-shadow_measurement = Measurements(protocol=Measurements.SHADOW, options=shadow_options)
-estimated_values_shadow = shadow_measurement(model)
+shadow_options = {"shadow_size": 54400, "shadow_groups": 6, "robust_correlations": [1.0 / 3.0] * 2}
+robust_shadow_measurement = Measurements(protocol=Measurements.ROBUST_SHADOW, options=shadow_options)
+estimated_values_robust_shadow = robust_shadow_measurement(model)
 
-print(f"Estimated expectation value = {estimated_values_shadow}") # markdown-exec: hide
+print(f"Estimated expectation value shadow = {estimated_values_robust_shadow}") # markdown-exec: hide
 ```
 
  `robust_correlations` are generally learned using a calibration scheme described in [^4,^5] that will come soon.

--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -59,6 +59,8 @@ print(f"Exact expectation value = {exact_values}") # markdown-exec: hide
 print(f"Estimated expectation value tomo = {estimated_values_tomo}") # markdown-exec: hide
 ```
 
+
+
 ## Classical shadows
 
 A much less resource demanding protocol based on _classical shadows_ has been proposed[^1]. It combines ideas from shadow tomography[^2] and randomized measurement protocols [^3] capable of learning a classical shadow of an unknown quantum state $\rho$. It relies on deliberately discarding the full classical characterization of the quantum state, and instead focuses on accurately predicting a restricted set of properties that provide efficient resources for the study of the system.
@@ -90,6 +92,9 @@ estimated_values_shadow = shadow_measurement(model)
 print(f"Estimated expectation value tomo = {estimated_values_shadow}") # markdown-exec: hide
 ```
 
+### Computing other
+
+
 ## Robust shadows
 
 Robust shadows [^4] were built upon the classical shadow scheme but have the particularity to be noise-resilient. Using an experimentally friendly calibration procedure, one can eﬃciently characterize and mitigate noises in the shadow estimation scheme, given only minimal assumptions on the experimental conditions. Such a procedure has been used in [^5] to estimate the Quantum Fisher information out of a quantum system. Note that robust shadows are equivalent to classical shadows in non-noisy settings by setting `robust_correlations` to $\frac{1}{3}$ for each qubit as follows:
@@ -103,6 +108,17 @@ print(f"Estimated expectation value = {estimated_values_shadow}") # markdown-exe
 ```
 
  `robust_correlations` are generally learned using a calibration scheme described in [^4,^5] that will come soon.
+
+### Getting measurements/shadows
+
+If we are interested in accessing the measurements or shadows for computing different quantities of interest other than the expectation values, we can simply pass `return_expectations=False` as follows:
+
+```python exec="on" source="material-block" session="measurements" result="json"
+
+measurements_tomo = tomo_measurement(model, return_expectations=False)
+
+print(measurements_tomo)
+```
 
 ## References
 

--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -90,6 +90,20 @@ estimated_values_shadow = shadow_measurement(model)
 print(f"Estimated expectation value tomo = {estimated_values_shadow}") # markdown-exec: hide
 ```
 
+## Robust shadows
+
+Robust shadows [^4] were built upon the classical shadow scheme but have the particularity to be noise-resilient. Using an experimentally friendly calibration procedure, one can eﬃciently characterize and mitigate noises in the shadow estimation scheme, given only minimal assumptions on the experimental conditions. Such a procedure has been used in [^5] to estimate the Quantum Fisher information out of a quantum system. Note that robust shadows are equivalent to classical shadows in non-noisy settings by setting `robust_correlations` to $\frac{1}{3}$ for each qubit as follows:
+
+```python exec="on" source="material-block" session="measurements" result="json"
+shadow_options = {"accuracy": 0.1, "confidence": 0.1, "robust": True, "robust_correlations": [1.0 / 3.0] * 2}
+shadow_measurement = Measurements(protocol=Measurements.SHADOW, options=shadow_options)
+estimated_values_shadow = shadow_measurement(model)
+
+print(f"Estimated expectation value = {estimated_values_shadow}") # markdown-exec: hide
+```
+
+ `robust_correlations` are generally learned using a calibration scheme described in [^4,^5] that will come soon.
+
 ## References
 
 [^1]: [Hsin-Yuan Huang, Richard Kueng and John Preskill, Predicting Many Properties of a Quantum System from Very Few Measurements (2020)](https://arxiv.org/abs/2002.08953)
@@ -97,3 +111,7 @@ print(f"Estimated expectation value tomo = {estimated_values_shadow}") # markdow
 [^2]: S. Aaronson. Shadow tomography of quantum states. In _Proceedings of the 50th Annual A ACM SIGACT Symposium on Theory of Computing_, STOC 2018, pages 325–338, New York, NY, USA, 2018. ACM
 
 [^3]: Aniket Rath. Probing entanglement on quantum platforms using randomized measurements. Physics \[physics\]. Université Grenoble Alpes \[2020-..\], 2023. English. ffNNT : 2023GRALY072ff. fftel-04523142
+
+[^4]: [Senrui Chen, Wenjun Yu, Pei Zeng, and Steven T. Flammia, Robust Shadow Estimation (2021)](https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.2.030348)
+
+[^5]: [Vittorio Vitale, Aniket Rath, Petar Jurcevic, Andreas Elben, Cyril Branciard, and Benoît Vermersch, Robust Estimation of the Quantum Fisher Information on a Quantum Processor (2024)](https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.5.030338)

--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -59,8 +59,6 @@ print(f"Exact expectation value = {exact_values}") # markdown-exec: hide
 print(f"Estimated expectation value tomo = {estimated_values_tomo}") # markdown-exec: hide
 ```
 
-
-
 ## Classical shadows
 
 A much less resource demanding protocol based on _classical shadows_ has been proposed[^1]. It combines ideas from shadow tomography[^2] and randomized measurement protocols [^3] capable of learning a classical shadow of an unknown quantum state $\rho$. It relies on deliberately discarding the full classical characterization of the quantum state, and instead focuses on accurately predicting a restricted set of properties that provide efficient resources for the study of the system.
@@ -91,9 +89,6 @@ estimated_values_shadow = shadow_measurement(model)
 
 print(f"Estimated expectation value tomo = {estimated_values_shadow}") # markdown-exec: hide
 ```
-
-### Computing other
-
 
 ## Robust shadows
 

--- a/qadence_protocols/measurements/protocols.py
+++ b/qadence_protocols/measurements/protocols.py
@@ -12,6 +12,7 @@ from qadence_protocols.protocols import Protocol
 PROTOCOL_TO_MODULE = {
     "tomography": "qadence_protocols.measurements.tomography",
     "shadow": "qadence_protocols.measurements.shadow",
+    "robust_shadow": "qadence_protocols.measurements.robust_shadow",
 }
 
 
@@ -19,6 +20,7 @@ PROTOCOL_TO_MODULE = {
 class Measurements(Protocol):
     TOMOGRAPHY = "tomography"
     SHADOW = "shadow"
+    ROBUST_SHADOW = "robust_shadow"
 
     def __init__(self, protocol: str, options: dict = dict()) -> None:
         super().__init__(protocol, options)
@@ -47,9 +49,9 @@ class Measurements(Protocol):
         observables = [obs.abstract for obs in conv_observables]
 
         # Partially pass the options and observable.
-        fct_to_import = "compute_expectation" if return_expectations else "compute_measurements"
+        compute_fn = "compute_expectation" if return_expectations else "compute_measurements"
         expectation = partial(
-            getattr(module, fct_to_import), observables=observables, options=self.options
+            getattr(module, compute_fn), observables=observables, options=self.options
         )
 
         return expectation(model, param_values=param_values)

--- a/qadence_protocols/measurements/protocols.py
+++ b/qadence_protocols/measurements/protocols.py
@@ -80,8 +80,8 @@ class Measurements(Protocol):
     ROBUST_SHADOW = "robust_shadow"
 
     def __init__(self, protocol: str, options: dict = dict()) -> None:
-        options_verifier = MeasurementOptions(protocol, options)
-        super().__init__(protocol, options_verifier.verify_options())
+        verified_options = MeasurementOptions(protocol, options).verify_options()
+        super().__init__(protocol, verified_options)
 
     def __call__(
         self,

--- a/qadence_protocols/measurements/protocols.py
+++ b/qadence_protocols/measurements/protocols.py
@@ -27,6 +27,7 @@ class Measurements(Protocol):
         self,
         model: QuantumModel,
         param_values: dict[str, Tensor] = dict(),
+        return_expectations: bool = True,
     ) -> Tensor:
         """Compute expectation values via measurements.
 
@@ -46,8 +47,9 @@ class Measurements(Protocol):
         observables = [obs.abstract for obs in conv_observables]
 
         # Partially pass the options and observable.
+        fct_to_import = "compute_expectation" if return_expectations else "compute_measurements"
         expectation = partial(
-            getattr(module, "compute_expectation"), observables=observables, options=self.options
+            getattr(module, fct_to_import), observables=observables, options=self.options
         )
 
         return expectation(model, param_values=param_values)

--- a/qadence_protocols/measurements/robust_shadow.py
+++ b/qadence_protocols/measurements/robust_shadow.py
@@ -12,7 +12,7 @@ def process_shadow_options(options: dict) -> tuple:
 
     shadow_size = options.get("shadow_size", None)
     if shadow_size is None:
-        raise KeyError("Shadow protocol requires either an option" "'shadow_size' of type 'int'.")
+        raise KeyError("Robust Shadow protocol requires an option 'shadow_size' of type 'int'.")
     shadow_groups = options.get("shadow_groups", None)
     if shadow_groups is None:
         raise KeyError("Shadow protocol requires either an option" "'shadow_groups' of type 'int'.")

--- a/qadence_protocols/measurements/robust_shadow.py
+++ b/qadence_protocols/measurements/robust_shadow.py
@@ -7,21 +7,6 @@ from torch import Tensor
 from qadence_protocols.measurements.utils_shadow import estimations
 
 
-def process_shadow_options(options: dict) -> tuple:
-    """Extract shadow_size, accuracy and confidence from options."""
-
-    shadow_size = options.get("shadow_size", None)
-    if shadow_size is None:
-        raise KeyError("Robust Shadow protocol requires an option 'shadow_size' of type 'int'.")
-    shadow_groups = options.get("shadow_groups", None)
-    if shadow_groups is None:
-        raise KeyError("Shadow protocol requires an option 'shadow_groups' of type 'int'.")
-
-    robust_shadow_correlations = options.get("robust_correlations", None)
-
-    return shadow_size, shadow_groups, robust_shadow_correlations
-
-
 def compute_measurements(
     model: QuantumModel,
     observables: list[AbstractBlock],
@@ -47,11 +32,9 @@ def compute_measurements(
     """
 
     circuit = model._circuit.original
-    (
-        shadow_size,
-        shadow_groups,
-        robust_shadow_correlations,
-    ) = process_shadow_options(options=options)
+    shadow_size = options["shadow_size"]
+    shadow_groups = options["shadow_groups"]
+    robust_shadow_correlations = options["robust_shadow_correlations"]
 
     return estimations(
         circuit=circuit,
@@ -94,11 +77,9 @@ def compute_expectation(
     """
 
     circuit = model._circuit.original
-    (
-        shadow_size,
-        shadow_groups,
-        robust_shadow_correlations,
-    ) = process_shadow_options(options=options)
+    shadow_size = options["shadow_size"]
+    shadow_groups = options["shadow_groups"]
+    robust_shadow_correlations = options["robust_shadow_correlations"]
 
     return estimations(
         circuit=circuit,

--- a/qadence_protocols/measurements/robust_shadow.py
+++ b/qadence_protocols/measurements/robust_shadow.py
@@ -15,7 +15,7 @@ def process_shadow_options(options: dict) -> tuple:
         raise KeyError("Robust Shadow protocol requires an option 'shadow_size' of type 'int'.")
     shadow_groups = options.get("shadow_groups", None)
     if shadow_groups is None:
-        raise KeyError("Shadow protocol requires either an option" "'shadow_groups' of type 'int'.")
+        raise KeyError("Shadow protocol requires an option 'shadow_groups' of type 'int'.")
 
     robust_shadow_correlations = options.get("robust_correlations", None)
 

--- a/qadence_protocols/measurements/robust_shadow.py
+++ b/qadence_protocols/measurements/robust_shadow.py
@@ -11,17 +11,21 @@ def process_shadow_options(options: dict) -> tuple:
     """Extract shadow_size, accuracy and confidence from options."""
 
     shadow_size = options.get("shadow_size", None)
-    accuracy = options.get("accuracy", None)
-    if shadow_size is None and accuracy is None:
+    if shadow_size is None:
         raise KeyError(
             "Shadow protocol requires either an option"
-            "'shadow_size' of type 'int' or 'accuracy' of type 'float'."
+            "'shadow_size' of type 'int'."
         )
-    confidence = options.get("confidence", None)
-    if confidence is None:
-        raise KeyError("Shadow protocol requires an option 'confidence' of type 'float'.")
+    shadow_groups = options.get("shadow_groups", None)
+    if shadow_groups is None:
+        raise KeyError(
+            "Shadow protocol requires either an option"
+            "'shadow_groups' of type 'int'."
+        )
 
-    return shadow_size, accuracy, confidence
+    robust_shadow_correlations = options.get("robust_correlations", None)
+
+    return shadow_size, shadow_groups, robust_shadow_correlations
 
 
 def compute_measurements(
@@ -51,8 +55,8 @@ def compute_measurements(
     circuit = model._circuit.original
     (
         shadow_size,
-        accuracy,
-        confidence,
+        shadow_groups,
+        robust_shadow_correlations,
     ) = process_shadow_options(options=options)
 
     return estimations(
@@ -60,12 +64,14 @@ def compute_measurements(
         observables=observables,
         param_values=model.embedding_fn(model._params, param_values),
         shadow_size=shadow_size,
-        accuracy=accuracy,
-        confidence_or_groups=confidence,
+        accuracy=None,
+        confidence_or_groups=shadow_groups,
         state=state,
         backend=model.backend,
         noise=model._noise,
         return_shadows=True,
+        robust_shadow=True,
+        robust_correlations=robust_shadow_correlations,
     )
 
 
@@ -96,8 +102,8 @@ def compute_expectation(
     circuit = model._circuit.original
     (
         shadow_size,
-        accuracy,
-        confidence,
+        shadow_groups,
+        robust_shadow_correlations,
     ) = process_shadow_options(options=options)
 
     return estimations(
@@ -105,10 +111,12 @@ def compute_expectation(
         observables=observables,
         param_values=model.embedding_fn(model._params, param_values),
         shadow_size=shadow_size,
-        accuracy=accuracy,
-        confidence_or_groups=confidence,
+        accuracy=None,
+        confidence_or_groups=shadow_groups,
         state=state,
         backend=model.backend,
         noise=model._noise,
         return_shadows=False,
+        robust_shadow=True,
+        robust_correlations=robust_shadow_correlations,
     )

--- a/qadence_protocols/measurements/robust_shadow.py
+++ b/qadence_protocols/measurements/robust_shadow.py
@@ -12,16 +12,10 @@ def process_shadow_options(options: dict) -> tuple:
 
     shadow_size = options.get("shadow_size", None)
     if shadow_size is None:
-        raise KeyError(
-            "Shadow protocol requires either an option"
-            "'shadow_size' of type 'int'."
-        )
+        raise KeyError("Shadow protocol requires either an option" "'shadow_size' of type 'int'.")
     shadow_groups = options.get("shadow_groups", None)
     if shadow_groups is None:
-        raise KeyError(
-            "Shadow protocol requires either an option"
-            "'shadow_groups' of type 'int'."
-        )
+        raise KeyError("Shadow protocol requires either an option" "'shadow_groups' of type 'int'.")
 
     robust_shadow_correlations = options.get("robust_correlations", None)
 
@@ -64,7 +58,7 @@ def compute_measurements(
         observables=observables,
         param_values=model.embedding_fn(model._params, param_values),
         shadow_size=shadow_size,
-        accuracy=None,
+        accuracy=0.0,
         confidence_or_groups=shadow_groups,
         state=state,
         backend=model.backend,
@@ -111,7 +105,7 @@ def compute_expectation(
         observables=observables,
         param_values=model.embedding_fn(model._params, param_values),
         shadow_size=shadow_size,
-        accuracy=None,
+        accuracy=0.0,
         confidence_or_groups=shadow_groups,
         state=state,
         backend=model.backend,

--- a/qadence_protocols/measurements/shadow.py
+++ b/qadence_protocols/measurements/shadow.py
@@ -7,6 +7,64 @@ from torch import Tensor
 from qadence_protocols.measurements.utils_shadow import estimations
 
 
+def process_shadow_options(options: dict) -> tuple:
+    """Extract shadow_size, accuracy and confidence from options."""
+
+    shadow_size = options.get("shadow_size", None)
+    accuracy = options.get("accuracy", None)
+    if shadow_size is None and accuracy is None:
+        raise KeyError(
+            "Shadow protocol requires either an option"
+            "'shadow_size' of type 'int' or 'accuracy' of type 'float'."
+        )
+    confidence = options.get("confidence", None)
+    if confidence is None:
+        raise KeyError("Shadow protocol requires an option 'confidence' of type 'float'.")
+
+    return shadow_size, accuracy, confidence
+
+
+def compute_measurements(
+    model: QuantumModel,
+    observables: list[AbstractBlock],
+    options: dict,
+    param_values: dict[str, Tensor] = dict(),
+    state: Tensor | None = None,
+) -> Tensor:
+    """
+    Construct a classical shadow of a state to estimate observable expectation values.
+
+    Args:
+        model (QuantumModel): Model to evaluate.
+        observables (list[AbstractBlock]): a list of observables
+            to estimate the expectation values from.
+        param_values (dict): a dict of values to substitute the
+            symbolic parameters for.
+        options (dict): a dict of options for the measurement protocol.
+            Here, shadow_size (int), accuracy (float) and confidence (float) are supported.
+        state (Tensor | None): an initial input state.
+
+    Returns:
+        expectations (Tensor): an estimation of the expectation values.
+    """
+
+    circuit = model._circuit.original
+    shadow_size, accuracy, confidence = process_shadow_options(options=options)
+
+    return estimations(
+        circuit=circuit,
+        observables=observables,
+        param_values=model.embedding_fn(model._params, param_values),
+        shadow_size=shadow_size,
+        accuracy=accuracy,
+        confidence=confidence,
+        state=state,
+        backend=model.backend,
+        noise=model._noise,
+        return_shadows=True,
+    )
+
+
 def compute_expectation(
     model: QuantumModel,
     observables: list[AbstractBlock],
@@ -32,17 +90,7 @@ def compute_expectation(
     """
 
     circuit = model._circuit.original
-
-    shadow_size = options.get("shadow_size", None)
-    accuracy = options.get("accuracy", None)
-    if shadow_size is None and accuracy is None:
-        raise KeyError(
-            "Shadow protocol requires either an option"
-            "'shadow_size' of type 'int' or 'accuracy' of type 'float'."
-        )
-    confidence = options.get("confidence", None)
-    if confidence is None:
-        raise KeyError("Shadow protocol requires an option 'confidence' of type 'float'.")
+    shadow_size, accuracy, confidence = process_shadow_options(options=options)
 
     return estimations(
         circuit=circuit,

--- a/qadence_protocols/measurements/shadow.py
+++ b/qadence_protocols/measurements/shadow.py
@@ -15,7 +15,7 @@ def process_shadow_options(options: dict) -> tuple:
     if shadow_size is None and accuracy is None:
         raise KeyError(
             "Shadow protocol requires either an option"
-            "'shadow_size' of type 'int' or 'accuracy' of type 'float'."
+            " 'shadow_size' of type 'int' or 'accuracy' of type 'float'."
         )
     confidence = options.get("confidence", None)
     if confidence is None:

--- a/qadence_protocols/measurements/shadow.py
+++ b/qadence_protocols/measurements/shadow.py
@@ -7,23 +7,6 @@ from torch import Tensor
 from qadence_protocols.measurements.utils_shadow import estimations
 
 
-def process_shadow_options(options: dict) -> tuple:
-    """Extract shadow_size, accuracy and confidence from options."""
-
-    shadow_size = options.get("shadow_size", None)
-    accuracy = options.get("accuracy", None)
-    if shadow_size is None and accuracy is None:
-        raise KeyError(
-            "Shadow protocol requires either an option"
-            " 'shadow_size' of type 'int' or 'accuracy' of type 'float'."
-        )
-    confidence = options.get("confidence", None)
-    if confidence is None:
-        raise KeyError("Shadow protocol requires an option 'confidence' of type 'float'.")
-
-    return shadow_size, accuracy, confidence
-
-
 def compute_measurements(
     model: QuantumModel,
     observables: list[AbstractBlock],
@@ -49,11 +32,9 @@ def compute_measurements(
     """
 
     circuit = model._circuit.original
-    (
-        shadow_size,
-        accuracy,
-        confidence,
-    ) = process_shadow_options(options=options)
+    shadow_size = options["shadow_size"]
+    accuracy = options["accuracy"]
+    confidence = options["confidence"]
 
     return estimations(
         circuit=circuit,
@@ -94,11 +75,9 @@ def compute_expectation(
     """
 
     circuit = model._circuit.original
-    (
-        shadow_size,
-        accuracy,
-        confidence,
-    ) = process_shadow_options(options=options)
+    shadow_size = options["shadow_size"]
+    accuracy = options["accuracy"]
+    confidence = options["confidence"]
 
     return estimations(
         circuit=circuit,

--- a/qadence_protocols/measurements/shadow.py
+++ b/qadence_protocols/measurements/shadow.py
@@ -21,7 +21,10 @@ def process_shadow_options(options: dict) -> tuple:
     if confidence is None:
         raise KeyError("Shadow protocol requires an option 'confidence' of type 'float'.")
 
-    return shadow_size, accuracy, confidence
+    robust_shadow = options.get("robust", False)
+    robust_shadow_correlations = options.get("robust_correlations", None)
+
+    return shadow_size, accuracy, confidence, robust_shadow, robust_shadow_correlations
 
 
 def compute_measurements(
@@ -49,7 +52,13 @@ def compute_measurements(
     """
 
     circuit = model._circuit.original
-    shadow_size, accuracy, confidence = process_shadow_options(options=options)
+    (
+        shadow_size,
+        accuracy,
+        confidence,
+        robust_shadow,
+        robust_shadow_correlations,
+    ) = process_shadow_options(options=options)
 
     return estimations(
         circuit=circuit,
@@ -62,6 +71,8 @@ def compute_measurements(
         backend=model.backend,
         noise=model._noise,
         return_shadows=True,
+        robust_shadow=robust_shadow,
+        robust_correlations=robust_shadow_correlations,
     )
 
 
@@ -90,7 +101,13 @@ def compute_expectation(
     """
 
     circuit = model._circuit.original
-    shadow_size, accuracy, confidence = process_shadow_options(options=options)
+    (
+        shadow_size,
+        accuracy,
+        confidence,
+        robust_shadow,
+        robust_shadow_correlations,
+    ) = process_shadow_options(options=options)
 
     return estimations(
         circuit=circuit,
@@ -102,4 +119,7 @@ def compute_expectation(
         state=state,
         backend=model.backend,
         noise=model._noise,
+        return_shadows=False,
+        robust_shadow=robust_shadow,
+        robust_correlations=robust_shadow_correlations,
     )

--- a/qadence_protocols/measurements/tomography.py
+++ b/qadence_protocols/measurements/tomography.py
@@ -19,7 +19,7 @@ def compute_measurements(
     param_values: dict[str, Tensor] = dict(),
     state: Tensor | None = None,
 ) -> list:
-    """Compute expectation values from the model by sampling via rotated circuits in Z-basis.
+    """Obtain measurements by sampling via rotated circuits in Z-basis.
 
     Args:
         model (QuantumModel): Model to evaluate.
@@ -35,7 +35,7 @@ def compute_measurements(
         KeyError: If a 'n_shots' kwarg of type 'int' is missing in options.
 
     Returns:
-        Tensor: Expectation values
+        list: List of samples per observable.
     """
 
     n_shots = options.get("n_shots")

--- a/qadence_protocols/measurements/tomography.py
+++ b/qadence_protocols/measurements/tomography.py
@@ -6,7 +6,59 @@ from qadence.blocks.abstract import AbstractBlock
 from qadence.blocks.utils import unroll_block_with_scaling
 from torch import Tensor
 
-from qadence_protocols.measurements.utils_tomography import iterate_pauli_decomposition
+from qadence_protocols.measurements.utils_tomography import (
+    convert_samples_to_pauli_expectation,
+    iterate_pauli_decomposition,
+)
+
+
+def compute_measurements(
+    model: QuantumModel,
+    observables: list[AbstractBlock],
+    options: dict,
+    param_values: dict[str, Tensor] = dict(),
+    state: Tensor | None = None,
+) -> list:
+    """Compute expectation values from the model by sampling via rotated circuits in Z-basis.
+
+    Args:
+        model (QuantumModel): Model to evaluate.
+        observables (list[ConvertedObservable]): a list of observables
+            to estimate the expectation values from.
+        options (dict): Tomography options.
+        Must be a dict with a 'n_shots' key and integer value.
+        param_values (dict[str, Tensor], optional): Parameter values. Defaults to dict().
+        state (Tensor, optional): Input state. Defaults to dict().
+
+    Raises:
+        TypeError: If observables are not given as list
+        KeyError: If a 'n_shots' kwarg of type 'int' is missing in options.
+
+    Returns:
+        Tensor: Expectation values
+    """
+
+    n_shots = options.get("n_shots")
+    if n_shots is None:
+        raise KeyError("Tomography protocol requires a 'n_shots' kwarg of type 'int').")
+
+    circuit = model._circuit.original
+
+    samples = []
+    for observable in observables:
+        pauli_decomposition = unroll_block_with_scaling(observable)
+        samples.append(
+            iterate_pauli_decomposition(
+                circuit=circuit,
+                param_values=model.embedding_fn(model._params, param_values),
+                pauli_decomposition=pauli_decomposition,
+                n_shots=n_shots,
+                state=state,
+                backend=model.backend,
+                noise=model._noise,
+            )
+        )
+    return samples
 
 
 def compute_expectation(
@@ -34,25 +86,12 @@ def compute_expectation(
     Returns:
         Tensor: Expectation values
     """
-
-    n_shots = options.get("n_shots")
-    if n_shots is None:
-        raise KeyError("Tomography protocol requires a 'n_shots' kwarg of type 'int').")
-
-    circuit = model._circuit.original
+    samples_obs = compute_measurements(model, observables, options, param_values, state)
 
     estimated_values = []
-    for observable in observables:
-        pauli_decomposition = unroll_block_with_scaling(observable)
+    for samples, observable in zip(samples_obs, observables):
         estimated_values.append(
-            iterate_pauli_decomposition(
-                circuit=circuit,
-                param_values=model.embedding_fn(model._params, param_values),
-                pauli_decomposition=pauli_decomposition,
-                n_shots=n_shots,
-                state=state,
-                backend=model.backend,
-                noise=model._noise,
-            )
+            convert_samples_to_pauli_expectation(samples, unroll_block_with_scaling(observable))
         )
+
     return torch.transpose(torch.vstack(estimated_values), 1, 0)

--- a/qadence_protocols/measurements/tomography.py
+++ b/qadence_protocols/measurements/tomography.py
@@ -38,10 +38,7 @@ def compute_measurements(
         list: List of samples per observable.
     """
 
-    n_shots = options.get("n_shots")
-    if n_shots is None:
-        raise KeyError("Tomography protocol requires a 'n_shots' kwarg of type 'int').")
-
+    n_shots = options["n_shots"]
     circuit = model._circuit.original
 
     samples = []

--- a/qadence_protocols/measurements/utils_shadow.py
+++ b/qadence_protocols/measurements/utils_shadow.py
@@ -110,6 +110,7 @@ def local_shadow(sample: Counter, unitary_ids: list) -> Tensor:
     else:
         return reduce(torch.kron, local_density_matrices)
 
+
 def robust_local_shadow(
     sample: Counter, unitary_ids: list, correlations: list | None = None
 ) -> Tensor:

--- a/qadence_protocols/measurements/utils_shadow.py
+++ b/qadence_protocols/measurements/utils_shadow.py
@@ -270,6 +270,7 @@ def estimations(
     backend: Backend | DifferentiableBackend = PyQBackend(),
     noise: Noise | None = None,
     endianness: Endianness = Endianness.BIG,
+    return_shadows: bool = False,
 ) -> Tensor:
     """Compute expectation values for all local observables using median of means."""
     # N is the estimated shot budget for the classical shadow to
@@ -287,6 +288,9 @@ def estimations(
         noise=noise,
         endianness=endianness,
     )
+    if return_shadows:
+        return shadow
+
     estimations = []
     for observable in observables:
         pauli_decomposition = unroll_block_with_scaling(observable)

--- a/qadence_protocols/measurements/utils_shadow.py
+++ b/qadence_protocols/measurements/utils_shadow.py
@@ -270,7 +270,7 @@ def estimations(
     param_values: dict,
     shadow_size: int | None = None,
     accuracy: float = 0.1,
-    confidence: float = 0.1,
+    confidence_or_groups: float | int = 0.1,
     state: Tensor | None = None,
     backend: Backend | DifferentiableBackend = PyQBackend(),
     noise: Noise | None = None,
@@ -283,9 +283,15 @@ def estimations(
     # N is the estimated shot budget for the classical shadow to
     # achieve desired accuracy for all L = len(observables) within 1 - confidence probablity.
     # K is the size of the shadow partition.
-    N, K = number_of_samples(observables=observables, accuracy=accuracy, confidence=confidence)
+    if robust_shadow:
+        K = int(confidence_or_groups)
+    else:
+        N, K = number_of_samples(
+            observables=observables, accuracy=accuracy, confidence=confidence_or_groups
+        )
     if shadow_size is not None:
         N = shadow_size
+
     shadow = classical_shadow(
         shadow_size=N,
         circuit=circuit,

--- a/qadence_protocols/measurements/utils_tomography.py
+++ b/qadence_protocols/measurements/utils_tomography.py
@@ -102,8 +102,52 @@ def iterate_pauli_decomposition(
     backend: Backend | DifferentiableBackend = PyQBackend(),
     noise: Noise | None = None,
     endianness: Endianness = Endianness.BIG,
+) -> list:
+    """Sample circuits given all Pauli terms.
+
+    Args:
+        circuit: The circuit that is executed.
+        param_values: Parameters of the circuit.
+        pauli_decomposition: A list of Pauli decomposed terms.
+        n_shots: Number of shots to sample.
+        state: Initial state.
+        backend: A backend for circuit execution.
+        noise: A noise model to use.
+        endianness: Endianness of the resulting bit strings.
+
+    Returns: A torch.Tensor of bit strings n_shots x n_qubits.
+    """
+
+    sample_values = list()  # type: ignore [var-annotated]
+
+    for pauli_term in pauli_decomposition:
+        if pauli_term[0].is_identity:
+            sample_values.append(list())
+        else:
+            # Rotate the circuit according to the given observable term.
+            rotated_circuit = rotate(circuit=circuit, pauli_term=pauli_term)
+            # Use the low-level backend API to avoid embedding of parameters
+            # already performed at the higher QuantumModel level.
+            # Therefore, parameters passed here have already been embedded.
+            conv_circ = backend.circuit(rotated_circuit)
+            sample_values.append(
+                backend.sample(
+                    circuit=conv_circ,
+                    param_values=param_values,
+                    n_shots=n_shots,
+                    state=state,
+                    noise=noise,
+                    endianness=endianness,
+                )
+            )
+    return sample_values
+
+
+def convert_samples_to_pauli_expectation(
+    samples_iteration: list,
+    pauli_decomposition: list[tuple[AbstractBlock, Basic]],
 ) -> Tensor:
-    """Estimate total expectation value by averaging all Pauli terms.
+    """Estimate total expectation value by averaging samples from all Pauli terms.
 
     Args:
         circuit: The circuit that is executed.
@@ -120,7 +164,7 @@ def iterate_pauli_decomposition(
 
     estimated_values = []
 
-    for pauli_term in pauli_decomposition:
+    for pauli_term, samples in zip(pauli_decomposition, samples_iteration):
         if pauli_term[0].is_identity:
             estimated_values.append(evaluate(pauli_term[1], as_torch=True))
         else:
@@ -129,20 +173,6 @@ def iterate_pauli_decomposition(
             # observables chaining multiple operations on the same qubit
             # such as `b = chain(Z(0), Z(0))`
             support = get_qubit_indices_for_op(pauli_term)
-            # Rotate the circuit according to the given observable term.
-            rotated_circuit = rotate(circuit=circuit, pauli_term=pauli_term)
-            # Use the low-level backend API to avoid embedding of parameters
-            # already performed at the higher QuantumModel level.
-            # Therefore, parameters passed here have already been embedded.
-            conv_circ = backend.circuit(rotated_circuit)
-            samples = backend.sample(
-                circuit=conv_circ,
-                param_values=param_values,
-                n_shots=n_shots,
-                state=state,
-                noise=noise,
-                endianness=endianness,
-            )
             estim_values = empirical_average(samples=samples, support=support)
             # TODO: support for parametric observables to be tested
             estimated_values.append(estim_values * evaluate(pauli_term[1]))

--- a/qadence_protocols/measurements/utils_tomography.py
+++ b/qadence_protocols/measurements/utils_tomography.py
@@ -73,29 +73,6 @@ def empirical_average(samples: list, support: list[int]) -> Tensor:
     return torch.tensor(expectations)
 
 
-def pauli_z_expectation(
-    pauli_decomposition: list[tuple[AbstractBlock, Basic]],
-    samples: list[Counter],
-) -> Tensor:
-    """Estimate total expectation value from samples by averaging all Pauli terms.
-
-    Args:
-        pauli_decomposition: A list of Pauli decomposed terms.
-        samples: Samples of bit string as Counters.
-
-    Returns: A torch.Tensor of the total expectation.
-    """
-
-    estimated_values = []
-    for pauli_term in pauli_decomposition:
-        support = get_qubit_indices_for_op(pauli_term)
-        estim_values = empirical_average(samples=samples, support=support)
-        # TODO: support for parametric observables to be tested
-        estimated_values.append(estim_values * evaluate(pauli_term[1]))
-    res = torch.sum(torch.stack(estimated_values), axis=0)
-    return res
-
-
 def rotate(circuit: QuantumCircuit, pauli_term: tuple[AbstractBlock, Basic]) -> QuantumCircuit:
     """Rotate circuit to measurement basis and return the qubit support.
 

--- a/qadence_protocols/mitigations/analog_zne.py
+++ b/qadence_protocols/mitigations/analog_zne.py
@@ -69,7 +69,7 @@ def pulse_experiment(
         converted_circuit = backend.circuit(stretched_circuit)
         noisy_density_matrices.append(
             # Contain a single experiment result for the stretch.
-            backend.run_dm(
+            backend.run(
                 converted_circuit,
                 param_values=param_values,
                 state=state,

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -246,23 +246,14 @@ def test_shadow_raise_errors() -> None:
     model = QuantumModel(
         circuit=QuantumCircuit(2, kron(X(0), X(1))), observable=None, backend=backend
     )
+
+    # Bad input keys
     options = {"accuracy": 0.1, "conf": 0.1}
     with pytest.raises(KeyError):
         shadow_measurement = Measurements(
             protocol=Measurements.SHADOW,
             options=options,
         )
-        expectation_sampled = shadow_measurement(model)
-
-    model = QuantumModel(
-        circuit=QuantumCircuit(2, kron(X(0), X(1))), observable=Z(0), backend=backend
-    )
-    with pytest.raises(KeyError):
-        shadow_measurement = Measurements(
-            protocol=Measurements.SHADOW,
-            options=options,
-        )
-        expectation_sampled = shadow_measurement(model)
 
     options = {"accuracies": 0.1, "confidence": 0.1}
     with pytest.raises(KeyError):
@@ -270,4 +261,3 @@ def test_shadow_raise_errors() -> None:
             protocol=Measurements.SHADOW,
             options=options,
         )
-        expectation_sampled = shadow_measurement(model)

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -247,25 +247,27 @@ def test_shadow_raise_errors() -> None:
         circuit=QuantumCircuit(2, kron(X(0), X(1))), observable=None, backend=backend
     )
     options = {"accuracy": 0.1, "conf": 0.1}
-    tomo_measurement = Measurements(
-        protocol=Measurements.SHADOW,
-        options=options,
-    )
-
-    with pytest.raises(TypeError):
-        expectation_sampled = tomo_measurement(model)
+    with pytest.raises(KeyError):
+        shadow_measurement = Measurements(
+            protocol=Measurements.SHADOW,
+            options=options,
+        )
+        expectation_sampled = shadow_measurement(model)
 
     model = QuantumModel(
         circuit=QuantumCircuit(2, kron(X(0), X(1))), observable=Z(0), backend=backend
     )
     with pytest.raises(KeyError):
-        expectation_sampled = tomo_measurement(model)
+        shadow_measurement = Measurements(
+            protocol=Measurements.SHADOW,
+            options=options,
+        )
+        expectation_sampled = shadow_measurement(model)
 
     options = {"accuracies": 0.1, "confidence": 0.1}
-    tomo_measurement = Measurements(
-        protocol=Measurements.SHADOW,
-        options=options,
-    )
-
     with pytest.raises(KeyError):
-        expectation_sampled = tomo_measurement(model)
+        shadow_measurement = Measurements(
+            protocol=Measurements.SHADOW,
+            options=options,
+        )
+        expectation_sampled = shadow_measurement(model)

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -232,7 +232,8 @@ def test_estimations_comparison_tomo_forward_pass(
     estimated_exp_shadow = shadow_measurements(model, param_values=values)
 
     robust_options = {"accuracy": 0.1, "confidence": 0.1, "robust": True}
-    robust_estimated_exp_shadow = shadow_measurements(model, param_values=robust_options)
+    robust_shadows = Measurements(protocol=Measurements.SHADOW, options=robust_options)
+    robust_estimated_exp_shadow = shadow_measurements(model, param_values=values)
 
     assert torch.allclose(estimated_exp_tomo, pyq_exp_exact, atol=1.0e-2)
     assert torch.allclose(estimated_exp_shadow, pyq_exp_exact, atol=0.1)

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -231,9 +231,9 @@ def test_estimations_comparison_tomo_forward_pass(
     # N = 54400.
     estimated_exp_shadow = shadow_measurements(model, param_values=values)
 
-    robust_options = {"accuracy": 0.1, "confidence": 0.1, "robust": True}
-    robust_shadows = Measurements(protocol=Measurements.SHADOW, options=robust_options)
-    robust_estimated_exp_shadow = shadow_measurements(model, param_values=values)
+    robust_options = {"shadow_size": 54400, "shadow_groups": 6, "robust_correlations": None}
+    robust_shadows = Measurements(protocol=Measurements.ROBUST_SHADOW, options=robust_options)
+    robust_estimated_exp_shadow = robust_shadows(model, param_values=values)
 
     assert torch.allclose(estimated_exp_tomo, pyq_exp_exact, atol=1.0e-2)
     assert torch.allclose(estimated_exp_shadow, pyq_exp_exact, atol=0.1)

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -230,9 +230,14 @@ def test_estimations_comparison_tomo_forward_pass(
     shadow_measurements = Measurements(protocol=Measurements.SHADOW, options=new_options)
     # N = 54400.
     estimated_exp_shadow = shadow_measurements(model, param_values=values)
+
+    robust_options = {"accuracy": 0.1, "confidence": 0.1, "robust": True}
+    robust_estimated_exp_shadow = shadow_measurements(model, param_values=robust_options)
+
     assert torch.allclose(estimated_exp_tomo, pyq_exp_exact, atol=1.0e-2)
     assert torch.allclose(estimated_exp_shadow, pyq_exp_exact, atol=0.1)
     assert torch.allclose(estimated_exp_shadow, pyq_exp_exact, atol=0.1)
+    assert torch.allclose(robust_estimated_exp_shadow, pyq_exp_exact, atol=0.1)
 
 
 def test_shadow_raise_errors() -> None:

--- a/tests/test_tomography.py
+++ b/tests/test_tomography.py
@@ -245,16 +245,9 @@ def test_tomography_raise_errors() -> None:
     notomo_model = QuantumModel(
         circuit=QuantumCircuit(2, kron(X(0), X(1))), observable=observable, backend=backend
     )
-    tomo_measurement = Measurements(
-        protocol=Measurements.TOMOGRAPHY,
-        options={"nsamples": 10000},
-    )
 
     with pytest.raises(TypeError):
-        expectation_sampled = tomo_measurement(notomo_model)
-
-    notomo_model = QuantumModel(
-        circuit=QuantumCircuit(2, kron(X(0), X(1))), observable=Z(0), backend=backend
-    )
-    with pytest.raises(KeyError):
-        expectation_sampled = tomo_measurement(notomo_model)
+        tomo_measurement = Measurements(
+            protocol=Measurements.TOMOGRAPHY,
+            options={"nsamples": 10000},
+        )

--- a/tests/test_tomography.py
+++ b/tests/test_tomography.py
@@ -246,7 +246,7 @@ def test_tomography_raise_errors() -> None:
         circuit=QuantumCircuit(2, kron(X(0), X(1))), observable=observable, backend=backend
     )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(KeyError):
         tomo_measurement = Measurements(
             protocol=Measurements.TOMOGRAPHY,
             options={"nsamples": 10000},


### PR DESCRIPTION
This PR introduces the concept of robust shadows. In a follow-up PR, we will add the calibration scheme that helps in estimating the `robust_correlations`. 

Also, a user may be interested in the measurements or shadows themselves for computing other quantities of interest. We tried to factor the current codebase so far for doing so, but suggestions are welcome how to refactor best.