### PR TITLE
[Refactor] Adding mitigation without model

### DIFF
--- a/docs/error_mitigation/readout_mitigation.md
+++ b/docs/error_mitigation/readout_mitigation.md
@@ -197,6 +197,40 @@ print(f"mitigated solution index: {result_index}" ) # markdown-exec: hide
 
 ### Model free mitigation
 
+You can perform the mitigation without a `quantum model` if you have sampled results from previous executions. This eliminates the need to reinitialize the circuit and sample again. Instead, you can directly apply the mitigation method to the existing data. To do this, you need to insert the `samples` at your `options` when initializing the `Mitigations` class.
+
+```python exec="on" source="material-block" session="mitigation" result="json"
+from qadence import QuantumModel, QuantumCircuit, hamiltonian_factory, kron, H, Z, I
+from qadence import NoiseProtocol, NoiseHandler
+from qadence_protocols.mitigations.protocols import Mitigations
+from qadence_protocols.types import ReadOutOptimization
+
+# Simple circuit and observable construction.
+block = kron(H(0), I(1))
+circuit = QuantumCircuit(2, block)
+n_shots = 10000
+
+# Construct a quantum model and noise
+model = QuantumModel(circuit=circuit)
+error_probability = 0.2
+noise = NoiseHandler(protocol=NoiseProtocol.READOUT.INDEPENDENT,options={"error_probability": error_probability})
+
+noiseless_samples = model.sample(n_shots=n_shots)
+noisy_samples = model.sample(noise=noise, n_shots=n_shots)
+
+# Define the mitigation method with the sample results
+options={"optimization_type": ReadOutOptimization.MAJ_VOTE, "n_shots": n_shots, "samples": noisy_samples}
+mitigation = Mitigations(protocol=Mitigations.READOUT, options=options)
+
+# Run noiseless, noisy and mitigated simulations.
+mitigated_samples_opt = mitigation(noise=noise)
+
+print(mitigated_samples_opt) # markdown-exec: hide
+
+```
+
+### Twirl mitigation
+
 This protocol makes use of all possible so-called twirl operations to average out the effect of readout errors into an effective scaling. The twirl operation consists of using bit flip operators before the measurement and after the measurement is obtained[^5]. The number of twirl operations can be reduced through random sampling. The method is exact in that it requires no calibration which might be prone to errors of modelling.
 
 ```python exec="on" source="material-block" session="mfm" result="json"

--- a/docs/error_mitigation/readout_mitigation.md
+++ b/docs/error_mitigation/readout_mitigation.md
@@ -219,13 +219,14 @@ noiseless_samples = model.sample(n_shots=n_shots)
 noisy_samples = model.sample(noise=noise, n_shots=n_shots)
 
 # Define the mitigation method with the sample results
-options={"optimization_type": ReadOutOptimization.MAJ_VOTE, "n_shots": n_shots, "samples": noisy_samples}
+options={"optimization_type": ReadOutOptimization.MLE, "n_shots": n_shots, "samples": noisy_samples}
 mitigation = Mitigations(protocol=Mitigations.READOUT, options=options)
 
 # Run noiseless, noisy and mitigated simulations.
 mitigated_samples_opt = mitigation(noise=noise)
 
-print(mitigated_samples_opt) # markdown-exec: hide
+print(f"Noisy samples: {noisy_samples}") # markdown-exec: hide
+print(f"Mitigates samples: {mitigated_samples_opt}") # markdown-exec: hide
 
 ```
 

--- a/qadence_protocols/mitigations/protocols.py
+++ b/qadence_protocols/mitigations/protocols.py
@@ -27,7 +27,7 @@ class Mitigations(Protocol):
 
     def __call__(
         self,
-        model: QuantumModel,
+        model: QuantumModel | None = None,
         noise: NoiseHandler | None = None,
         param_values: dict[str, Tensor] = dict(),
     ) -> list[Counter]:

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -90,7 +90,7 @@ from qadence_protocols.types import ReadOutOptimization
         ),
     ],
 )
-def test_readout_mitigation_quantum_model(
+def test_readout_mitigation(
     error_probability: float,
     n_shots: int,
     block: AbstractBlock,
@@ -113,6 +113,17 @@ def test_readout_mitigation_quantum_model(
         options={"optimization_type": optimization_type, "samples": noisy_samples},
     )
     mitigated_samples = mitigate(model=model, noise=noise)
+
+    js_mitigated = js_divergence(mitigated_samples[0], noiseless_samples[0])
+    js_noisy = js_divergence(noisy_samples[0], noiseless_samples[0])
+    assert js_mitigated < js_noisy
+
+    # Pass the noisy samples to the mitigation protocol and run without model
+    mitigate = Mitigations(
+        protocol=Mitigations.READOUT,
+        options={"optimization_type": optimization_type, "samples": noisy_samples},
+    )
+    mitigated_samples = mitigate(noise=noise)
 
     js_mitigated = js_divergence(mitigated_samples[0], noiseless_samples[0])
     js_noisy = js_divergence(noisy_samples[0], noiseless_samples[0])


### PR DESCRIPTION
Closes #23 .

- [x] Readout `mitigate` function works without the `model` parameter if `samples` are specified
- [x] Test and documentation related to the issue are added

